### PR TITLE
Adjust the width of the Transaction column output dynamically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: "maven-publish"
+apply plugin: 'eclipse'
 
 repositories {
   jcenter()
@@ -7,6 +8,7 @@ repositories {
 
 dependencies {
   compile 'org.springframework:spring-context:4.2.2.RELEASE'
+  compile 'commons-lang:commons-lang:2.6'
 
   testCompile 'org.springframework:spring-test:4.2.2.RELEASE'
   testCompile 'org.jmockit:jmockit:1.20'

--- a/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
+++ b/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
@@ -6,9 +6,9 @@ import org.apache.commons.lang.StringUtils;
 
 public class TransactionPrinter {
 	static private class TransactionDataSummaryEntry {
-		private String transactionName;
-		private String average;
-		private String count;
+		private final String transactionName;
+		private final String average;
+		private final String count;
 		
 		public TransactionDataSummaryEntry(String transactionName, String average, String count) {
 			this.transactionName = transactionName;

--- a/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
+++ b/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
@@ -33,7 +33,8 @@ public class TransactionPrinter {
 		static private final String TRANSACTION_HEADER = "Transaction";
 		static private final String AVERAGE_HEADER = "Average";
 		static private final String COUNT_HEADER = "Count";
-		static private final int MAX_ROW_WIDTH = 119;
+		static private final int MAX_ROW_WIDTH = 120;
+		static private final int CONSOLE_MAX_ROW_WIDTH = MAX_ROW_WIDTH - 1;
 		static private final String ROW_FORMAT = "%%-%ds | %%10s | %%10s%n";
 		static private final int PRE_ALLOCATED_SPACE_PER_ROW = 26;
 		static private final String ELLIPSIS = "...";
@@ -72,7 +73,7 @@ public class TransactionPrinter {
 		}
 		
 		private int getTransactionColumnWidth() {
-			return Math.min(MAX_ROW_WIDTH - PRE_ALLOCATED_SPACE_PER_ROW, longestTransactionNameLength);
+			return Math.min(CONSOLE_MAX_ROW_WIDTH - PRE_ALLOCATED_SPACE_PER_ROW, longestTransactionNameLength);
 		}
 		
 		private String getTransactionDisplayName(String transactionName) {

--- a/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
+++ b/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
@@ -1,59 +1,101 @@
 package org.roy.loadx.transaction;
 
 import java.util.ArrayList;
-import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
 
 public class TransactionPrinter {
+	static private class TransactionDataSummaryEntry {
+		private String transactionName;
+		private String average;
+		private String count;
+		
+		public TransactionDataSummaryEntry(String transactionName, String average, String count) {
+			this.transactionName = transactionName;
+			this.average = average;
+			this.count = count;
+		}
+
+		public String getTransactionName() {
+			return transactionName;
+		}
+
+		public String getAverage() {
+			return average;
+		}
+
+		public String getCount() {
+			return count;
+		}
+	}
+	
+	static private class TransactionDataSummary {
+		static private final String TRANSACTION_HEADER = "Transaction";
+		static private final String AVERAGE_HEADER = "Average";
+		static private final String COUNT_HEADER = "Count";
+		static private final int MAX_ROW_WIDTH = 78;
+		static private final String ROW_FORMAT = "%%-%ds | %%10s | %%10s%n";
+		static private final int PRE_ALLOCATED_SPACE_PER_ROW = 26;
+		
+		private int maxTransactionNameLength;
+		private ArrayList<TransactionDataSummaryEntry> rows;
+		
+		public TransactionDataSummary() {
+			maxTransactionNameLength = TRANSACTION_HEADER.length();
+			rows = new ArrayList<TransactionDataSummaryEntry>();
+		}
+		
+		public void add(TransactionDataSummaryEntry entry) {
+			rows.add(entry);
+			int txNameLength = entry.getTransactionName().length();
+			if (txNameLength > maxTransactionNameLength) {
+				maxTransactionNameLength = txNameLength;
+			}
+		}
+		
+		@Override
+		public String toString() {
+			int txColumnWidth = getTransactionColumnWidth();
+			String rowFormat = computeDynamicFormatString();
+			StringBuilder sb = new StringBuilder();
+			sb.append(String.format(rowFormat, TRANSACTION_HEADER, AVERAGE_HEADER, COUNT_HEADER));
+			sb.append(String.format(rowFormat, StringUtils.repeat("=", txColumnWidth), StringUtils.repeat("=", AVERAGE_HEADER.length()), StringUtils.repeat("=", COUNT_HEADER.length())));
+			for (TransactionDataSummaryEntry entry : rows) {
+				String name = entry.getTransactionName();
+				if (name.length() > txColumnWidth) {
+					name = name.substring(0, txColumnWidth - 3) + "...";
+				}
+				sb.append(String.format(rowFormat, name, entry.getAverage(), entry.getCount()));
+			}
+			return sb.toString();
+		}
+		
+		private String computeDynamicFormatString() {
+			return String.format(ROW_FORMAT, getTransactionColumnWidth());
+		}
+		
+		private int getTransactionColumnWidth() {
+			return Math.min(MAX_ROW_WIDTH - PRE_ALLOCATED_SPACE_PER_ROW, maxTransactionNameLength);
+		}
+	}
+	
 	private final TransactionAggregator transactionAggregator;
 
 	public TransactionPrinter(TransactionAggregator transactionAggregator) {
 		this.transactionAggregator = transactionAggregator;
 	}
 
-	private static void println() {
-		System.out.println();
-		System.out.flush();
-	}
-
-	private static void format(String format, Object... args) {
-		System.out.format(format, args);
-		System.out.flush();
-		println();
-	}
-
 	public void print() {
-		List<String[]> output = new ArrayList<>();
-		output.add(new String[] {"Transaction", "Average", "Count"});
-		int maxTxLength = 11; // length of 'Transaction'
-		
+		TransactionDataSummary summary = new TransactionDataSummary();
 		for (String name : transactionAggregator.getSortedTransactionNames()) {
 			TransactionData transactionData = transactionAggregator.getTransactionData(name);
 			long roundedAverage = Math.round(transactionData.getAverageDurationMilli());
 			String average = String.valueOf(roundedAverage);
 			String count = String.valueOf(transactionData.getTransactionCount());
-			output.add(new String[] {name, average, count});
-			if(name.length() > maxTxLength)
-				maxTxLength = name.length();
+			summary.add(new TransactionDataSummaryEntry(name, average, count));
 		}
-		printFormatted(output, maxTxLength);
-	}
-
-	private void printFormatted(final List<String[]> data, final int maxTxLength) {
-		int rowWidth = 78; // adjust to taste
-		int txWidth = Math.min(rowWidth - 26, maxTxLength); // 26 is based on space needed for other cols using existing format
-		
-		// insert the header separator based on the dynamically generated length
-		StringBuilder sb = new StringBuilder();
-		for(int i = 0; i < txWidth; ++i)
-			sb.append("=");
-		data.add(1, new String[] {sb.toString(), "==========", "=========="});
-
-		String fmtString = String.format("%%-%ds | %%10s | %%10s", txWidth);
-		for(String[] row : data) {
-			if(row[0].length() > txWidth)
-				row[0] = row[0].substring(0, txWidth - 3) + "...";
-			format(fmtString, row[0], row[1], row[2]);
-		}
-		println();
+		System.out.println(summary);
+		System.out.flush();
+		System.out.println();
 	}
 }

--- a/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
+++ b/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
@@ -1,5 +1,8 @@
 package org.roy.loadx.transaction;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class TransactionPrinter {
 	private final TransactionAggregator transactionAggregator;
 
@@ -19,19 +22,38 @@ public class TransactionPrinter {
 	}
 
 	public void print() {
-		printFormatted("Transaction", "Average", "Count");
-		printFormatted("===========", "=======", "=====");
+		List<String[]> output = new ArrayList<>();
+		output.add(new String[] {"Transaction", "Average", "Count"});
+		int maxTxLength = 11; // length of 'Transaction'
+		
 		for (String name : transactionAggregator.getSortedTransactionNames()) {
 			TransactionData transactionData = transactionAggregator.getTransactionData(name);
 			long roundedAverage = Math.round(transactionData.getAverageDurationMilli());
 			String average = String.valueOf(roundedAverage);
 			String count = String.valueOf(transactionData.getTransactionCount());
-			printFormatted(name, average, count);
+			output.add(new String[] {name, average, count});
+			if(name.length() > maxTxLength)
+				maxTxLength = name.length();
 		}
-		println();
+		printFormatted(output, maxTxLength);
 	}
 
-	private void printFormatted(String name, String count, String average) {
-		format("%-15s | %10s | %10s", name, count, average);
+	private void printFormatted(final List<String[]> data, final int maxTxLength) {
+		int rowWidth = 78; // adjust to taste
+		int txWidth = Math.min(rowWidth - 26, maxTxLength); // 26 is based on space needed for other cols using existing format
+		
+		// insert the header separator based on the dynamically generated length
+		StringBuilder sb = new StringBuilder();
+		for(int i = 0; i < txWidth; ++i)
+			sb.append("=");
+		data.add(1, new String[] {sb.toString(), "==========", "=========="});
+
+		String fmtString = String.format("%%-%ds | %%10s | %%10s", txWidth);
+		for(String[] row : data) {
+			if(row[0].length() > txWidth)
+				row[0] = row[0].substring(0, txWidth - 3) + "...";
+			format(fmtString, row[0], row[1], row[2]);
+		}
+		println();
 	}
 }

--- a/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
+++ b/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
@@ -33,7 +33,7 @@ public class TransactionPrinter {
 		static private final String TRANSACTION_HEADER = "Transaction";
 		static private final String AVERAGE_HEADER = "Average";
 		static private final String COUNT_HEADER = "Count";
-		static private final int MAX_ROW_WIDTH = 78;
+		static private final int MAX_ROW_WIDTH = 119;
 		static private final String ROW_FORMAT = "%%-%ds | %%10s | %%10s%n";
 		static private final int PRE_ALLOCATED_SPACE_PER_ROW = 26;
 		static private final String ELLIPSIS = "...";

--- a/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
+++ b/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
@@ -38,19 +38,19 @@ public class TransactionPrinter {
 		static private final int PRE_ALLOCATED_SPACE_PER_ROW = 26;
 		static private final String ELLIPSIS = "...";
 		
-		private int maxTransactionNameLength;
+		private int longestTransactionNameLength;
 		private ArrayList<TransactionDataSummaryEntry> rows;
 		
 		public TransactionDataSummary() {
-			maxTransactionNameLength = TRANSACTION_HEADER.length();
+			longestTransactionNameLength = TRANSACTION_HEADER.length();
 			rows = new ArrayList<>();
 		}
 		
 		public void add(TransactionDataSummaryEntry entry) {
 			rows.add(entry);
 			int transactionNameLength = entry.getTransactionName().length();
-			if (transactionNameLength > maxTransactionNameLength) {
-				maxTransactionNameLength = transactionNameLength;
+			if (transactionNameLength > longestTransactionNameLength) {
+				longestTransactionNameLength = transactionNameLength;
 			}
 		}
 		
@@ -72,7 +72,7 @@ public class TransactionPrinter {
 		}
 		
 		private int getTransactionColumnWidth() {
-			return Math.min(MAX_ROW_WIDTH - PRE_ALLOCATED_SPACE_PER_ROW, maxTransactionNameLength);
+			return Math.min(MAX_ROW_WIDTH - PRE_ALLOCATED_SPACE_PER_ROW, longestTransactionNameLength);
 		}
 		
 		private String getTransactionDisplayName(String transactionName) {

--- a/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
+++ b/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
@@ -81,6 +81,16 @@ public class TransactionPrinter {
 		}
 	}
 	
+	static private void println() {
+		System.out.println();
+		System.out.flush();
+	}
+	
+	static private void println(Object obj) {
+		System.out.println(obj);
+		println();
+	}
+	
 	private final TransactionAggregator transactionAggregator;
 
 	public TransactionPrinter(TransactionAggregator transactionAggregator) {
@@ -96,8 +106,6 @@ public class TransactionPrinter {
 			String count = String.valueOf(transactionData.getTransactionCount());
 			summary.add(new TransactionDataSummaryEntry(name, average, count));
 		}
-		System.out.println(summary);
-		System.out.println();
-		System.out.flush();
+		println(summary);
 	}
 }

--- a/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
+++ b/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
@@ -36,6 +36,7 @@ public class TransactionPrinter {
 		static private final int MAX_ROW_WIDTH = 78;
 		static private final String ROW_FORMAT = "%%-%ds | %%10s | %%10s%n";
 		static private final int PRE_ALLOCATED_SPACE_PER_ROW = 26;
+		static private final String ELLIPSIS = "...";
 		
 		private int maxTransactionNameLength;
 		private ArrayList<TransactionDataSummaryEntry> rows;
@@ -76,10 +77,7 @@ public class TransactionPrinter {
 		
 		private String getTransactionDisplayName(String transactionName) {
 			int transactionColumnWidth = getTransactionColumnWidth();
-			if (transactionName.length() > transactionColumnWidth) {
-				return transactionName.substring(0, transactionColumnWidth - 3) + "...";
-			}
-			return transactionName;
+			return transactionName.length() > transactionColumnWidth ? transactionName.substring(0, transactionColumnWidth - ELLIPSIS.length()) + ELLIPSIS : transactionName;
 		}
 	}
 	

--- a/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
+++ b/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
@@ -42,30 +42,26 @@ public class TransactionPrinter {
 		
 		public TransactionDataSummary() {
 			maxTransactionNameLength = TRANSACTION_HEADER.length();
-			rows = new ArrayList<TransactionDataSummaryEntry>();
+			rows = new ArrayList<>();
 		}
 		
 		public void add(TransactionDataSummaryEntry entry) {
 			rows.add(entry);
-			int txNameLength = entry.getTransactionName().length();
-			if (txNameLength > maxTransactionNameLength) {
-				maxTransactionNameLength = txNameLength;
+			int transactionNameLength = entry.getTransactionName().length();
+			if (transactionNameLength > maxTransactionNameLength) {
+				maxTransactionNameLength = transactionNameLength;
 			}
 		}
 		
 		@Override
 		public String toString() {
-			int txColumnWidth = getTransactionColumnWidth();
+			int transactionColumnWidth = getTransactionColumnWidth();
 			String rowFormat = computeDynamicFormatString();
 			StringBuilder sb = new StringBuilder();
 			sb.append(String.format(rowFormat, TRANSACTION_HEADER, AVERAGE_HEADER, COUNT_HEADER));
-			sb.append(String.format(rowFormat, StringUtils.repeat("=", txColumnWidth), StringUtils.repeat("=", AVERAGE_HEADER.length()), StringUtils.repeat("=", COUNT_HEADER.length())));
+			sb.append(String.format(rowFormat, StringUtils.repeat("=", transactionColumnWidth), StringUtils.repeat("=", AVERAGE_HEADER.length()), StringUtils.repeat("=", COUNT_HEADER.length())));
 			for (TransactionDataSummaryEntry entry : rows) {
-				String name = entry.getTransactionName();
-				if (name.length() > txColumnWidth) {
-					name = name.substring(0, txColumnWidth - 3) + "...";
-				}
-				sb.append(String.format(rowFormat, name, entry.getAverage(), entry.getCount()));
+				sb.append(String.format(rowFormat, getTransactionDisplayName(entry.getTransactionName()), entry.getAverage(), entry.getCount()));
 			}
 			return sb.toString();
 		}
@@ -76,6 +72,14 @@ public class TransactionPrinter {
 		
 		private int getTransactionColumnWidth() {
 			return Math.min(MAX_ROW_WIDTH - PRE_ALLOCATED_SPACE_PER_ROW, maxTransactionNameLength);
+		}
+		
+		private String getTransactionDisplayName(String transactionName) {
+			int transactionColumnWidth = getTransactionColumnWidth();
+			if (transactionName.length() > transactionColumnWidth) {
+				return transactionName.substring(0, transactionColumnWidth - 3) + "...";
+			}
+			return transactionName;
 		}
 	}
 	
@@ -95,7 +99,7 @@ public class TransactionPrinter {
 			summary.add(new TransactionDataSummaryEntry(name, average, count));
 		}
 		System.out.println(summary);
-		System.out.flush();
 		System.out.println();
+		System.out.flush();
 	}
 }

--- a/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
+++ b/src/main/java/org/roy/loadx/transaction/TransactionPrinter.java
@@ -81,14 +81,9 @@ public class TransactionPrinter {
 		}
 	}
 	
-	static private void println() {
-		System.out.println();
+	static private void println(String str) {
+		System.out.println(str);
 		System.out.flush();
-	}
-	
-	static private void println(Object obj) {
-		System.out.println(obj);
-		println();
 	}
 	
 	private final TransactionAggregator transactionAggregator;
@@ -106,6 +101,6 @@ public class TransactionPrinter {
 			String count = String.valueOf(transactionData.getTransactionCount());
 			summary.add(new TransactionDataSummaryEntry(name, average, count));
 		}
-		println(summary);
+		println(summary.toString());
 	}
 }


### PR DESCRIPTION
Adjust the width of the tx column based on the longest name found.  The
entire row width is limited to 78 chars to avoid wrapping on most
terminals.  Any tx name longer than the max available width will be
truncated with an ellipsis to maintain the formatting.

Sample output:

```
Transaction                                          |    Average |      Count
==================================================== | ========== | ==========
endfsdfser3rffvx342432wesfsdsdfvzdfh3429342973sgh... |          0 |          4
run                                                  |          0 |          8
start                                                |          0 |          4
```