### PR TITLE
Fix bug with Util.findBoundaries()

### DIFF
--- a/src/main/java/org/roy/loadx/Util.java
+++ b/src/main/java/org/roy/loadx/Util.java
@@ -1,10 +1,30 @@
 package org.roy.loadx;
 
 public class Util {
+	
 	public static String findBoundaries(String leftBoundary, String rightBoundary, String str) {
-		int leftPos = str.indexOf(leftBoundary) + leftBoundary.length();
-		int rightPos = str.indexOf(rightBoundary, leftPos);
-		return str.substring(leftPos, rightPos);
+		// no specifics given as to what to do in these cases, assuming an exception should be thrown
+		if (str == null) {
+			throw new IllegalArgumentException("Source string cannot be null!");
+		} else if (leftBoundary == null) {
+			throw new IllegalArgumentException("Left boundary cannot be null nor zero-length!");
+		} else if (rightBoundary == null) {
+			throw new IllegalArgumentException("Right boundary cannot be null nor zero-length!");
+		} else {
+			int leftPos = str.indexOf(leftBoundary);
+			int rightPos = str.indexOf(rightBoundary);
+
+			// no specifics given as to what happens in these cases, assuming an exception better than IOB is appropriate
+			if (leftPos == -1) {
+				throw new IllegalArgumentException(String.format("Left boundary '%s' does not exist in source '%s'!", leftBoundary, str));
+			}
+			
+			if (rightPos == -1) {
+				throw new IllegalArgumentException(String.format("Right boundary '%s' does not exist in source '%s'!", rightBoundary, str));
+			}
+			
+			return str.substring(leftPos + leftBoundary.length(), rightPos);
+		}
 	}
 
 	public static void sleep(long millis) {

--- a/src/main/java/org/roy/loadx/Util.java
+++ b/src/main/java/org/roy/loadx/Util.java
@@ -4,14 +4,13 @@ public class Util {
 	
 	public static String findBoundaries(String leftBoundary, String rightBoundary, String str) {
 		int leftPos = str.indexOf(leftBoundary);
-		int rightPos = str.indexOf(rightBoundary);
-
 		if (leftPos == -1) {
-			throw new IllegalArgumentException(String.format("Left boundary '%s' does not exist in source '%s'!", leftBoundary, str));
+			throw new IllegalArgumentException(String.format("Left boundary %s does not exist in string: %s", leftBoundary, str));
 		}
 
+		int rightPos = str.indexOf(rightBoundary);
 		if (rightPos == -1) {
-			throw new IllegalArgumentException(String.format("Right boundary '%s' does not exist in source '%s'!", rightBoundary, str));
+			throw new IllegalArgumentException(String.format("Right boundary %s does not exist in string: %s", rightBoundary, str));
 		}
 
 		return str.substring(leftPos + leftBoundary.length(), rightPos);

--- a/src/main/java/org/roy/loadx/Util.java
+++ b/src/main/java/org/roy/loadx/Util.java
@@ -3,28 +3,18 @@ package org.roy.loadx;
 public class Util {
 	
 	public static String findBoundaries(String leftBoundary, String rightBoundary, String str) {
-		// no specifics given as to what to do in these cases, assuming an exception should be thrown
-		if (str == null) {
-			throw new IllegalArgumentException("Source string cannot be null!");
-		} else if (leftBoundary == null) {
-			throw new IllegalArgumentException("Left boundary cannot be null nor zero-length!");
-		} else if (rightBoundary == null) {
-			throw new IllegalArgumentException("Right boundary cannot be null nor zero-length!");
-		} else {
-			int leftPos = str.indexOf(leftBoundary);
-			int rightPos = str.indexOf(rightBoundary);
+		int leftPos = str.indexOf(leftBoundary);
+		int rightPos = str.indexOf(rightBoundary);
 
-			// no specifics given as to what happens in these cases, assuming an exception better than IOB is appropriate
-			if (leftPos == -1) {
-				throw new IllegalArgumentException(String.format("Left boundary '%s' does not exist in source '%s'!", leftBoundary, str));
-			}
-			
-			if (rightPos == -1) {
-				throw new IllegalArgumentException(String.format("Right boundary '%s' does not exist in source '%s'!", rightBoundary, str));
-			}
-			
-			return str.substring(leftPos + leftBoundary.length(), rightPos);
+		if (leftPos == -1) {
+			throw new IllegalArgumentException(String.format("Left boundary '%s' does not exist in source '%s'!", leftBoundary, str));
 		}
+
+		if (rightPos == -1) {
+			throw new IllegalArgumentException(String.format("Right boundary '%s' does not exist in source '%s'!", rightBoundary, str));
+		}
+
+		return str.substring(leftPos + leftBoundary.length(), rightPos);
 	}
 
 	public static void sleep(long millis) {

--- a/src/test/java/org/roy/loadx/TestUtil.java
+++ b/src/test/java/org/roy/loadx/TestUtil.java
@@ -34,28 +34,19 @@ public class TestUtil {
 	}
 
 	@Test(expected=IllegalArgumentException.class)
-	public void testFindBoundariesWithBoundariesMissing() {
-		String src = String.format("abcfoobarxyz");
+	public void testFindBoundariesWithLeftBoundaryMissing() {
+		String src = String.format("abcfoobarxyz%s", RIGHT_BOUNDARY);
 		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, src);
-	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public void testFindBoundariesWithNullSource() {
-		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, null);
-	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public void testFindBoundariesWithEmptySource() {
-		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, "");
 	}
 
 	@Test(expected=IllegalArgumentException.class)
-	public void testFindBoundariesWithNullLeftBoundary() {
-		Util.findBoundaries(null, RIGHT_BOUNDARY, "foo");
+	public void testFindBoundariesWithRightBoundaryMissing() {
+		String src = String.format("abc%sfoobarxyz", LEFT_BOUNDARY);
+		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, src);
 	}
-	
+		
 	@Test(expected=IllegalArgumentException.class)
-	public void testFindBoundariesWithNullRightBoundary() {
-		Util.findBoundaries(LEFT_BOUNDARY, null, "foo");
+	public void testFindBoundariesWithEmptySource() {
+		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, "");
 	}
 }

--- a/src/test/java/org/roy/loadx/TestUtil.java
+++ b/src/test/java/org/roy/loadx/TestUtil.java
@@ -34,19 +34,19 @@ public class TestUtil {
 	}
 
 	@Test(expected=IllegalArgumentException.class)
-	public void testFindBoundariesWithLeftBoundaryMissing() {
+	public void findBoundariesThrowsWithMissingLeftBoundary() {
 		String src = String.format("abcfoobarxyz%s", RIGHT_BOUNDARY);
 		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, src);
 	}
 
 	@Test(expected=IllegalArgumentException.class)
-	public void testFindBoundariesWithRightBoundaryMissing() {
+	public void findBoundariesThrowsWithMissingRightBoundary() {
 		String src = String.format("abc%sfoobarxyz", LEFT_BOUNDARY);
 		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, src);
 	}
 		
 	@Test(expected=IllegalArgumentException.class)
-	public void testFindBoundariesWithEmptySource() {
+	public void findBoundariesThrowsWithEmptyStringAndNonEmptyBoundaries() {
 		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, "");
 	}
 }

--- a/src/test/java/org/roy/loadx/TestUtil.java
+++ b/src/test/java/org/roy/loadx/TestUtil.java
@@ -1,0 +1,61 @@
+package org.roy.loadx;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TestUtil {
+
+	static private final String LEFT_BOUNDARY = "ABC";
+	static private final String RIGHT_BOUNDARY = "XYZ";
+	
+	@Test
+	public void testFindBoundariesWithValidBoundariesInMiddle() {
+		String src = String.format("00fv%sfoobar%s123", LEFT_BOUNDARY, RIGHT_BOUNDARY);
+		assertEquals("foobar", Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, src));
+	}
+
+	@Test
+	public void testFindBoundariesWithValidBoundariesOnLeftEdge() {
+		String src = String.format("%sfoobar%s123", LEFT_BOUNDARY, RIGHT_BOUNDARY);
+		assertEquals("foobar", Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, src));
+	}
+
+	@Test
+	public void testFindBoundariesWithValidBoundariesOnRightEdge() {
+		String src = String.format("00123%sfoobar%s", LEFT_BOUNDARY, RIGHT_BOUNDARY);
+		assertEquals("foobar", Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, src));
+	}
+
+	@Test
+	public void testFindBoundariesWithValidBoundariesOnBothEdges() {
+		String src = String.format("%sfoobar%s", LEFT_BOUNDARY, RIGHT_BOUNDARY);
+		assertEquals("foobar", Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, src));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testFindBoundariesWithBoundariesMissing() {
+		String src = String.format("abcfoobarxyz");
+		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, src);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testFindBoundariesWithNullSource() {
+		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, null);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testFindBoundariesWithEmptySource() {
+		Util.findBoundaries(LEFT_BOUNDARY, RIGHT_BOUNDARY, "");
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testFindBoundariesWithNullLeftBoundary() {
+		Util.findBoundaries(null, RIGHT_BOUNDARY, "foo");
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testFindBoundariesWithNullRightBoundary() {
+		Util.findBoundaries(LEFT_BOUNDARY, null, "foo");
+	}
+}


### PR DESCRIPTION
Function assumed both boundaries existed in the source string.  If they
didn't, you'd end up getting an unexpected result or an IndexOutOfBounds
exception.  Function would also throw an NPE if str was null.

This commit address all of the issues above, throwing a descriptive
IllegalArgumentException when the arguments given don't allow for an
expected result to be returned; also avoids throwing less than
desireable IndexOutOfBounds or NPE exceptions as well.